### PR TITLE
Exclude promo and ad blocks from parsed Onliner article text

### DIFF
--- a/onliner_bot.py
+++ b/onliner_bot.py
@@ -139,6 +139,12 @@ class OnlinerClient:
 
         paragraphs: List[str] = []
         if body:
+            for unwanted_block in body.select(".news-promo, .news-banner, .news-last, .news-comment, .news-reference"):
+                unwanted_block.decompose()
+
+            for ad_container in body.find_all("div", id=re.compile(r"^adfox_", re.IGNORECASE)):
+                ad_container.decompose()
+
             for paragraph in body.find_all("p"):
                 text = paragraph.get_text(" ", strip=True)
                 if text and not contains_unwanted_body_text(text):


### PR DESCRIPTION
### Motivation
- Onliner inserted inline promo/ad blocks (for example `div.news-promo`) into article bodies and their text was being picked up for summarization, polluting Telegram summaries.

### Description
- Updated `_extract_body_paragraphs` in `onliner_bot.py` to remove non-editorial blocks selected by `.news-promo, .news-banner, .news-last, .news-comment, .news-reference` before extracting `<p>` text by calling `decompose()` on those elements.
- Added removal of ad containers matching `div` elements with `id` starting with `adfox_` using `find_all("div", id=re.compile(r"^adfox_", re.IGNORECASE))` to prevent embedded ad scripts/containers from contributing text.
- Retained the existing paragraph extraction and unwanted-text filtering logic (`contains_unwanted_body_text`) after cleaning the article body.

### Testing
- Ran `python -m py_compile onliner_bot.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25b575890832a8dad5d28398932d5)